### PR TITLE
Remove "engines" from library's package.json

### DIFF
--- a/projects/harvest/ng-perfect-scrollbar/package.json
+++ b/projects/harvest/ng-perfect-scrollbar/package.json
@@ -26,9 +26,5 @@
     "typescript",
     "angular",
     "perfect-scrollbar"
-  ],
-  "engines": {
-    "node": "20.14.0",
-    "npm": "10.7.0"
-  }
+  ]
 }


### PR DESCRIPTION
There is no reason to force library users to use particular Node.js version.

The "engines" key were added in commit 4d57805a2b68cf5a6fbe68385f66805a51ac055d, probably by mistake.